### PR TITLE
Restructured to enable mocking of FirebaseAuth

### DIFF
--- a/app/src/main/java/net/jmhossler/roastd/logintask/LoginActivity.java
+++ b/app/src/main/java/net/jmhossler/roastd/logintask/LoginActivity.java
@@ -5,6 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 
 import net.jmhossler.roastd.R;
 import net.jmhossler.roastd.util.ActivityUtils;
+import com.google.firebase.auth.FirebaseAuth;
 
 /**
  * Activity to handle Google login.
@@ -25,7 +26,8 @@ public class LoginActivity extends AppCompatActivity {
       ActivityUtils.addFragmentToActivity(getSupportFragmentManager(),
         loginFragment, R.id.loginFrame);
     }
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance();
 
-    mLoginPresenter = new LoginPresenter(loginFragment);
+    mLoginPresenter = new LoginPresenter(loginFragment, firebaseAuth);
   }
 }

--- a/app/src/main/java/net/jmhossler/roastd/logintask/LoginPresenter.java
+++ b/app/src/main/java/net/jmhossler/roastd/logintask/LoginPresenter.java
@@ -28,11 +28,11 @@ public class LoginPresenter implements LoginContract.Presenter {
   @NonNull
   private final LoginContract.View mLoginView;
 
-  public LoginPresenter(@NonNull LoginContract.View loginView) {
+  public LoginPresenter(@NonNull LoginContract.View loginView, @NonNull FirebaseAuth firebaseAuth) {
     mLoginView = loginView;
     mLoginView.setPresenter(this);
 
-    mAuth = FirebaseAuth.getInstance();
+    mAuth = firebaseAuth;
   }
 
   @Override

--- a/app/src/test/java/net/jmhossler/roastd/logintask/LoginPresenterTest.java
+++ b/app/src/test/java/net/jmhossler/roastd/logintask/LoginPresenterTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.google.firebase.auth.FirebaseAuth;
+
 import static org.mockito.Mockito.verify;
 
 /**
@@ -33,6 +35,9 @@ public class LoginPresenterTest {
 
   private LoginPresenter mLoginPresenter;
 
+  @Mock
+  private FirebaseAuth mAuth;
+
   @Before
   public void setupTasksPresenter() {
     // Mockito has a very convenient way to inject mocks by using the @Mock annotation. To
@@ -40,13 +45,13 @@ public class LoginPresenterTest {
     MockitoAnnotations.initMocks(this);
 
     // Get a reference to the class under test
-    mLoginPresenter = new LoginPresenter(mLoginView);
+    mLoginPresenter = new LoginPresenter(mLoginView, mAuth);
   }
 
   @Test
   public void createPresenter_setsThePresenterToView() {
     // Get a reference to the class under test
-    mLoginPresenter = new LoginPresenter(mLoginView);
+    mLoginPresenter = new LoginPresenter(mLoginView, mAuth);
 
     // Then the presenter is set to the view
     verify(mLoginView).setPresenter(mLoginPresenter);


### PR DESCRIPTION
This fixes the tests. I think the issue was falling FirebaseAuth.getInstance() within a context that didn't have access to actual android APIs or an Android OS. The unit tests do not use those, so we have to structure things in a way to enable easier mocking.